### PR TITLE
Switch deprecated exchange() in favor of exchangeToMono(..)

### DIFF
--- a/complete/src/main/java/hello/GreetingWebClient.java
+++ b/complete/src/main/java/hello/GreetingWebClient.java
@@ -1,20 +1,32 @@
 package hello;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
-
 import reactor.core.publisher.Mono;
 
 public class GreetingWebClient {
-	private WebClient client = WebClient.create("http://localhost:8080");
 
-	private Mono<ClientResponse> result = client.get()
-			.uri("/hello")
-			.accept(MediaType.TEXT_PLAIN)
-			.exchange();
+	private final String result;
+
+	public GreetingWebClient() {
+
+		WebClient client = WebClient.create("http://localhost:8080");
+		WebClient.RequestHeadersUriSpec<?> requestHeadersUriSpec = client.get();
+		requestHeadersUriSpec.uri("/hello").accept(MediaType.TEXT_PLAIN);
+		Mono<String> response = requestHeadersUriSpec.exchangeToMono(res -> {
+			if (res.statusCode().equals(HttpStatus.OK))
+				return res.bodyToMono(String.class);
+			if (res.statusCode().is4xxClientError())
+				return Mono.just("Error response: ".concat(res.statusCode().getReasonPhrase()));
+			return res.createException().flatMap(Mono::error);
+		});
+
+		result = response.block();
+
+	}
 
 	public String getResult() {
-		return ">> result = " + result.flatMap(res -> res.bodyToMono(String.class)).block();
+		return result;
 	}
 }

--- a/complete/src/main/java/hello/GreetingWebClient.java
+++ b/complete/src/main/java/hello/GreetingWebClient.java
@@ -29,4 +29,5 @@ public class GreetingWebClient {
 	public String getResult() {
 		return result;
 	}
+
 }


### PR DESCRIPTION
In the `GreetingWebClient()` class there is a call to `.exchange()` which is deprecated.
The code has been updated to `exchangeToMono(res ->  ..)` in addition to minor refactoring.